### PR TITLE
Add 404 page and clarify Netlify deployment steps

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,19 @@
+name: Deploy to Netlify
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to Netlify
+        uses: netlify/actions/cli@master
+        with:
+          args: deploy --prod --dir=.
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+

--- a/404.html
+++ b/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page Not Found</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; background-color: #f4f4f4; }
+        h1 { font-size: 3em; margin-bottom: 20px; }
+        p { margin-bottom: 20px; }
+        a { color: #4CAF50; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <h1>Page Not Found</h1>
+    <p>Looks like you've followed a broken link or entered a URL that doesn't exist on this site.</p>
+    <p><a href="/">Back to Login Page</a></p>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# basicloginpage
+# Basic Login Page
+
+This repository contains a simple HTML login page. Open `index.html` in your browser to see it in action or serve it locally with:
+
+```bash
+python3 -m http.server 8000
+```
+
+Visit `http://localhost:8000` in your browser to view the page.
+
+## Hosting online with GitHub Pages
+
+If you want to share the login page publicly, you can host it for free using GitHub Pages:
+
+1. Create a repository on GitHub and push these files to it.
+2. In the repository's **Settings** page, find the **Pages** section.
+3. Choose the main branch (and `/root` if asked) as the source, then save.
+4. After a few moments, your page will be available at `https://<username>.github.io/<repository-name>/`.
+
+That's it! You now have a simple login page served online.
+
+## Hosting with Netlify
+
+Netlify is another free option for serving static sites:
+
+1. Sign up at [Netlify](https://www.netlify.com/) and choose **Add new site** > **Import an existing project**.
+2. Connect your GitHub repository that contains this login page.
+3. Leave the build command empty since this is a static site and keep the publish directory as `/` (the repository root).
+4. Click **Deploy site**. Netlify will provide a live URL that you can share.
+5. If you encounter a "Page not found" message, make sure the publish directory is set to `/` and that `index.html` is in the repository root. You can also include a simple `404.html` to customize the error page.
+
+## Hosting with Render
+
+Render offers a similar approach for static sites:
+
+1. Create an account at [Render](https://render.com/).
+2. From the dashboard, click **New Static Site** and connect your GitHub repo.
+3. No build command is needed; set the publish directory to `/`.
+4. Hit **Create Static Site** and Render will deploy your login page with its own URL.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login Page</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .login-container {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            width: 300px;
+        }
+        .login-container h2 {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .login-container label {
+            display: block;
+            margin-bottom: 5px;
+        }
+        .login-container input[type="text"],
+        .login-container input[type="password"] {
+            width: 100%;
+            padding: 8px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        .login-container input[type="submit"] {
+            width: 100%;
+            padding: 10px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .login-container input[type="submit"]:hover {
+            background-color: #45a049;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <h2>Login</h2>
+        <form>
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" required>
+
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>
+
+            <input type="submit" value="Login">
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `404.html` fallback
- clarify Netlify instructions in the README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f5256f2d08325bbdc1ae4b6582445